### PR TITLE
fix "carousel and modal settings not respected"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,13 +20,13 @@ class Lightbox {
 			size: 'xl',
 			constrain: true
 		});
+		this.settings = Object.assign(Object.assign({}, this.settings), options);
 		this.modalOptions = (() => this.setOptionsFromSettings(bootstrap.Modal.Default))();
 		this.carouselOptions = (() => this.setOptionsFromSettings(bootstrap.Carousel.Default))();
 		if (typeof el === 'string') {
 			this.settings.target = el;
 			el = document.querySelector(this.settings.target);
 		}
-		this.settings = Object.assign(Object.assign({}, this.settings), options);
 		this.el = el;
 		this.type = el.dataset.type || '';
 


### PR DESCRIPTION
I've tried to adjust the carousel `interval` but it remained the default from `bootstrap.Carousel.Default`.

`setOptionsFromSettings()` is using `this.settings`, but that has not yet been merged with `options` at that point.

Related to https://github.com/trvswgnr/bs5-lightbox/issues/46