### PR TITLE
Import bootstrap plugins individual

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@
  * @module bs5-lightbox
  */
 
-import { Modal, Carousel } from 'bootstrap';
+import Modal from 'bootstrap/js/dist/Modal';
+import Carousel from 'bootstrap/js/dist/carousel';
+
 const bootstrap = {
 	Modal,
 	Carousel


### PR DESCRIPTION
When utilising the old method, it would cause it to bundle all of `bootstrap.esm.js`. With this method, it only pulls in modal and carousel into a compiled webpack.